### PR TITLE
feat: refresh search results styling and copy

### DIFF
--- a/components/search/SearchResults.tsx
+++ b/components/search/SearchResults.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, type SVGProps } from 'react';
 import NoResults from '@/components/search/NoResults';
 import { useSearchResults } from '@/hooks/use-search-results';
 import { saveBookingData } from '@/lib/booking-utils';
+import { toTitleCase } from '@/lib/strings';
 import type {
   SearchResultsData,
   SearchQueryParams,
@@ -20,6 +21,82 @@ const SORT_OPTIONS: Array<{ value: SortValue; label: string }> = [
   { value: 'capacity_desc', label: 'Capacity: High to Low' },
   { value: 'capacity_asc', label: 'Capacity: Low to High' },
 ];
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+function MapPinIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 21.75s-7.5-4.108-7.5-11.25a7.5 7.5 0 1115 0c0 7.142-7.5 11.25-7.5 11.25z" />
+      <circle cx="12" cy="10.5" r="2.25" />
+    </svg>
+  );
+}
+
+function FlagIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M4.5 3v18" />
+      <path d="M4.5 5.25l4.5-1.5 4.5 1.5v9l-4.5-1.5-4.5 1.5" />
+    </svg>
+  );
+}
+
+function ClockIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7.5v5.25l3 1.5" />
+    </svg>
+  );
+}
+
+function CarIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M19 17h2c.6 0 1-.4 1-1v-3c0-.9-.7-1.7-1.5-1.9C18.7 10.6 16 10 16 10s-1.3-1.4-2.2-2.3c-.5-.4-1.1-.7-1.8-.7H5c-.6 0-1.1.4-1.4.9l-1.4 2.9A3.7 3.7 0 0 0 2 12v4c0 .6.4 1 1 1h2" />
+      <circle cx="7" cy="17" r="2" />
+      <path d="M9 17h6" />
+      <circle cx="17" cy="17" r="2" />
+    </svg>
+  );
+}
 
 interface SearchResultsProps {
   initialData: SearchResultsData | null;
@@ -66,6 +143,16 @@ export default function SearchResults({ initialData, searchParams }: SearchResul
     error,
     activeFilterCount = 0,
   } = useSearchResults(initialData) || {};
+
+  const originLabel = useMemo(
+    () => toTitleCase(results?.origin?.displayName ?? searchParams.origin ?? ''),
+    [results?.origin?.displayName, searchParams.origin],
+  );
+
+  const destinationLabel = useMemo(
+    () => toTitleCase(results?.destination?.displayName ?? searchParams.destination ?? ''),
+    [results?.destination?.displayName, searchParams.destination],
+  );
 
   const summaryDate = results?.pickupDateTime ? formatDateParts(results.pickupDateTime) : '';
   const summaryDistance = results?.distance ? formatDistance(results.distance) : '';
@@ -173,19 +260,42 @@ export default function SearchResults({ initialData, searchParams }: SearchResul
   }
 
   const displayDistance = summaryDistance ? `${summaryDistance}` : undefined;
+  const distanceDurationText = [displayDistance, results?.duration]
+    .filter(Boolean)
+    .join(' • ');
+  const pickupText = summaryDate ? `Pickup: ${summaryDate}` : '';
 
   return (
     <div className="search-results__container">
       <header className="card search-results__header" aria-live="polite">
         <div>
           <h1 className="search-results__title">
-            {results.origin.displayName} → {results.destination.displayName}
+            <span className="search-results__location">
+              <MapPinIcon className="icon-24" />
+              <span>{originLabel}</span>
+            </span>
+            <span className="search-results__arrow" aria-hidden="true">
+              →
+            </span>
+            <span className="search-results__location">
+              <FlagIcon className="icon-24" />
+              <span>{destinationLabel}</span>
+            </span>
           </h1>
-          <p className="search-results__meta">
-            {displayDistance && <span>{displayDistance}</span>}
-            {results.duration && <span>{results.duration}</span>}
-            {summaryDate && <span>{summaryDate}</span>}
-          </p>
+          <ul className="search-results__meta" role="list">
+            {distanceDurationText && (
+              <li>
+                <CarIcon className="icon-20" />
+                <span>{distanceDurationText}</span>
+              </li>
+            )}
+            {pickupText && (
+              <li>
+                <ClockIcon className="icon-20" />
+                <span>{pickupText}</span>
+              </li>
+            )}
+          </ul>
         </div>
         <button type="button" className="pill" onClick={handleEditSearch}>
           Edit search

--- a/lib/strings.ts
+++ b/lib/strings.ts
@@ -1,0 +1,9 @@
+export function toTitleCase(label: string): string {
+  if (!label) return '';
+
+  return label
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+    .replace(/\b([a-z])/g, (match) => match.toUpperCase());
+}

--- a/pages/api/search-results.js
+++ b/pages/api/search-results.js
@@ -4,7 +4,7 @@ const MOCK_CAB_OPTIONS = [
         id: 'hatchback-1',
         category: 'Economy',
         carType: 'hatchback',
-        carExamples: ['Maruti Swift', 'Hyundai i20', 'Tata Tiago'],
+        carExamples: ['Maruti Swift', 'Maruti WagonR'],
         capacity: 4,
         features: ['AC', 'Music System', 'Clean Interior'],
         price: 0, // Will be calculated based on distance
@@ -19,7 +19,7 @@ const MOCK_CAB_OPTIONS = [
         id: 'sedan-1',
         category: 'Comfort',
         carType: 'sedan',
-        carExamples: ['Honda City', 'Maruti Ciaz', 'Hyundai Verna'],
+        carExamples: ['Maruti Swift Dzire', 'Toyota Etios', 'Hyundai Aura'],
         capacity: 4,
         features: ['AC', 'Music System', 'Comfortable Seats', 'Extra Legroom'],
         price: 0, // Will be calculated
@@ -32,9 +32,9 @@ const MOCK_CAB_OPTIONS = [
     },
     {
         id: 'suv-1',
-        category: 'Premium',
+        category: 'Premium — 7 Seater',
         carType: 'suv',
-        carExamples: ['Toyota Innova', 'Mahindra XUV700', 'Tata Safari'],
+        carExamples: ['Maruti Ertiga'],
         capacity: 7,
         features: ['AC', 'Music System', 'Spacious Interior', 'Premium Comfort', 'Extra Luggage Space'],
         price: 0, // Will be calculated
@@ -47,10 +47,10 @@ const MOCK_CAB_OPTIONS = [
     },
     {
         id: 'luxury-1',
-        category: 'Luxury',
+        category: 'Luxury — 7 Seater',
         carType: 'luxury',
-        carExamples: ['Mercedes E-Class', 'BMW 5 Series', 'Audi A6'],
-        capacity: 4,
+        carExamples: ['Toyota Innova'],
+        capacity: 7,
         features: ['Premium AC', 'Premium Music System', 'Leather Seats', 'Chauffeur Service', 'Complimentary Water'],
         price: 0, // Will be calculated
         estimatedDuration: '0 mins',

--- a/pages/api/search-results.ts
+++ b/pages/api/search-results.ts
@@ -7,7 +7,7 @@ const MOCK_CAB_OPTIONS: CabOption[] = [
     id: 'hatchback-1',
     category: 'Economy',
     carType: 'hatchback',
-    carExamples: ['Maruti Swift', 'Hyundai i20', 'Tata Tiago'],
+    carExamples: ['Maruti Swift', 'Maruti WagonR'],
     capacity: 4,
     features: ['AC', 'Music System', 'Clean Interior'],
     price: 0, // Will be calculated based on distance
@@ -22,7 +22,7 @@ const MOCK_CAB_OPTIONS: CabOption[] = [
     id: 'sedan-1',
     category: 'Comfort',
     carType: 'sedan',
-    carExamples: ['Honda City', 'Maruti Ciaz', 'Hyundai Verna'],
+    carExamples: ['Maruti Swift Dzire', 'Toyota Etios', 'Hyundai Aura'],
     capacity: 4,
     features: ['AC', 'Music System', 'Comfortable Seats', 'Extra Legroom'],
     price: 0, // Will be calculated
@@ -35,9 +35,9 @@ const MOCK_CAB_OPTIONS: CabOption[] = [
   },
   {
     id: 'suv-1',
-    category: 'Premium',
+    category: 'Premium — 7 Seater',
     carType: 'suv',
-    carExamples: ['Toyota Innova', 'Mahindra XUV700', 'Tata Safari'],
+    carExamples: ['Maruti Ertiga'],
     capacity: 7,
     features: ['AC', 'Music System', 'Spacious Interior', 'Premium Comfort', 'Extra Luggage Space'],
     price: 0, // Will be calculated
@@ -50,10 +50,10 @@ const MOCK_CAB_OPTIONS: CabOption[] = [
   },
   {
     id: 'luxury-1',
-    category: 'Luxury',
+    category: 'Luxury — 7 Seater',
     carType: 'luxury',
-    carExamples: ['Mercedes E-Class', 'BMW 5 Series', 'Audi A6'],
-    capacity: 4,
+    carExamples: ['Toyota Innova'],
+    capacity: 7,
     features: ['Premium AC', 'Premium Music System', 'Leather Seats', 'Chauffeur Service', 'Complimentary Water'],
     price: 0, // Will be calculated
     estimatedDuration: '0 mins',

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -55,6 +55,9 @@
   --brand-secondary: var(--color-secondary-500);
   --brand-accent: #0f766e;
   --brand-muted: var(--color-gray-500);
+  --primary: var(--color-primary-700);
+  --muted: var(--color-gray-500);
+  --surface-tint: #f8fafc;
 
   /* Background Colors */
   --color-bg-primary: #ffffff;
@@ -724,7 +727,7 @@ table {
 }
 
 .muted {
-  color: var(--brand-muted);
+  color: var(--muted);
   font-size: var(--font-size-sm);
 }
 
@@ -957,6 +960,7 @@ table {
 }
 
 /* Search Results */
+
 .search-results__container {
   display: flex;
   flex-direction: column;
@@ -967,33 +971,73 @@ table {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  background: var(--surface-tint);
+  border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .search-results__title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
   font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-semibold);
+  color: var(--primary);
+}
+
+.search-results__location {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.search-results__location svg,
+.search-results__meta svg {
+  flex-shrink: 0;
+}
+
+.search-results__arrow {
+  color: var(--muted);
+  font-size: var(--font-size-xl);
 }
 
 .search-results__meta {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-2);
+  gap: var(--space-3);
+  list-style: none;
+  padding: 0;
+  margin: var(--space-2) 0 0;
   font-size: var(--font-size-sm);
-  color: var(--brand-muted);
+  color: var(--muted);
 }
 
-.search-results__meta span::after {
+.search-results__meta li {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.search-results__meta li + li {
+  padding-left: var(--space-2);
+}
+
+.search-results__meta li + li::before {
   content: '';
   display: inline-block;
   width: 4px;
   height: 4px;
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.6);
-  margin: 0 var(--space-2);
+  margin-right: var(--space-2);
 }
 
-.search-results__meta span:last-child::after {
-  content: none;
+@media (min-width: 768px) {
+  .search-results__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
 }
 
 .search-results__toolbar {
@@ -1001,6 +1045,8 @@ table {
   flex-wrap: wrap;
   gap: var(--space-4);
   align-items: flex-end;
+  background: var(--surface-tint);
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .search-results__list {
@@ -1019,11 +1065,13 @@ table {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  flex: 1;
 }
 
 .search-card__title {
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-semibold);
+  color: var(--primary);
 }
 
 .search-card__features {
@@ -1033,12 +1081,12 @@ table {
   display: grid;
   gap: var(--space-2);
   font-size: var(--font-size-sm);
-  color: var(--brand-muted);
+  color: var(--muted);
 }
 
 .search-card__features li::before {
   content: '•';
-  color: var(--brand-accent);
+  color: var(--primary);
   margin-right: var(--space-2);
 }
 
@@ -1058,8 +1106,20 @@ table {
 
 .search-card__price {
   font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-semibold);
-  color: var(--brand-primary-dark);
+  font-weight: var(--font-weight-bold);
+  color: var(--primary);
+}
+
+@media (min-width: 768px) {
+  .search-card__body {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .search-card__meta {
+    align-items: flex-end;
+    text-align: right;
+  }
 }
 
 .search-results__message {

--- a/tests/strings.test.ts
+++ b/tests/strings.test.ts
@@ -1,0 +1,16 @@
+import { toTitleCase } from '../lib/strings';
+
+describe('toTitleCase', () => {
+  it('capitalizes each word', () => {
+    expect(toTitleCase('raipur durg')).toBe('Raipur Durg');
+  });
+
+  it('handles extra spaces and hyphenated names', () => {
+    expect(toTitleCase('  bhilai   nagar ')).toBe('Bhilai Nagar');
+    expect(toTitleCase('new-town east')).toBe('New-Town East');
+  });
+
+  it('returns empty string for falsy values', () => {
+    expect(toTitleCase('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure route labels on the search results page use a reusable title-case helper and add contextual icons for the summary bar
- apply a subtle tint and brand-colored accents to the results header, toolbar, and cards while keeping layout intact
- refresh mock cab data to show the requested model lists per category and cover the new 7-seater labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d144742a1483229a114794778b22ac